### PR TITLE
Fix typo in author list of gurtler22a

### DIFF
--- a/_posts/2022-08-31-gurtler22a.md
+++ b/_posts/2022-08-31-gurtler22a.md
@@ -39,7 +39,7 @@ bibtex_author: G\"urtler, Nico and Widmaier, Felix and Sancaktar, Cansu and Blae
   Markus and Riedmiller, Martin and Allshire, Arthur and Wang, Qiang and McCarthy,
   Robert and Kim, Hangyeol and Baek, Jongchan and Kwon, Wookyong and Qian, Shanliang
   and Toshimitsu, Yasunori and Michelis, Mike Yan and Kazemipour, Amirhossein and
-  Raayatsanati, Arman and Zheng, Hehui and Cangan, Barnabasa Gavin and Sch\"olkopf,
+  Raayatsanati, Arman and Zheng, Hehui and Cangan, Barnabas Gavin and Sch\"olkopf,
   Bernhard and Martius, Georg
 author:
 - given: Nico
@@ -84,7 +84,7 @@ author:
   family: Raayatsanati
 - given: Hehui
   family: Zheng
-- given: Barnabasa Gavin
+- given: Barnabas Gavin
   family: Cangan
 - given: Bernhard
   family: Schölkopf


### PR DESCRIPTION
We noticed a typo in the author list we provided. This pull request fixes this typo. We apologize for the inconvenience.